### PR TITLE
docs(templates): copy-paste ready cluster and app examples with credential discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,40 @@ Before you begin, ensure you have:
 
 ## Quick Start
 
+**Option A — Provision a new cluster (AWS EKS)**
 ```bash
-# 1. Install CLI
+# 1. Install CLI + login
 curl -fsSL https://astropulse.io/install.sh | bash
-
-# 2. Login
 astroctl auth login
 
-# 3. Deploy a cluster (update accountId and region in the yaml first)
+# 2. Link your AWS account (one-time per cluster)
+astroctl cloud aws connect --account-id <YOUR_AWS_ACCOUNT_ID> --cluster-name my-cluster --region us-east-1
+
+# 3. Deploy cluster (update accountId and region in the yaml first)
 astroctl infra k8s apply -f cluster-template/aws/eks/byoa.yaml
 
-# 4. Access the cluster
-astroctl infra k8s set-context <cluster-name>
-
-# 5. Deploy an application
+# 4. Access and deploy
+astroctl infra k8s set-context my-cluster
 astroctl app apply -f apps/hello-world/demo.yaml
+astroctl app status hello-world
+```
 
-# 6. Check status
+**Option B — Register an existing cluster (any provider)**
+```bash
+# 1. Install CLI + login
+curl -fsSL https://astropulse.io/install.sh | bash
+astroctl auth login
+
+# 2. Register (deploys a lightweight agent via your current kubectl context)
+astroctl infra k8s register --cluster-name my-cluster
+
+# 3. (Optional) Link cloud provider for upgrade/scale/delete operations
+#    AWS:   astroctl cloud aws connect --account-id <ID> --cluster-name my-cluster --region <region>
+#    GCP:   astroctl cloud gcp connect --project-id <PROJECT> --cluster-name my-cluster --region <region>
+#    Azure: astroctl cloud azure connect --subscription-id <ID> --resource-group <RG> --cluster-name my-cluster --region <region>
+
+# 4. Deploy
+astroctl app apply -f apps/hello-world/demo.yaml
 astroctl app status hello-world
 ```
 
@@ -54,8 +71,9 @@ astroctl app status hello-world
 1. [Download astroctl CLI](#download-astroctl-cli)
 2. [Generate API Key](#generate-api-key-to-interact-with-astro-platform)
 3. [Deploy an EKS Cluster](#deploy-an-eks-cluster)
-4. [Manage Clusters](#available-clusters-and-their-state)
-5. [Deploy Application Profiles](#deploy-application-profiles)
+4. [Register an Existing Cluster (BYOK)](#register-an-existing-cluster-byok)
+5. [Manage Clusters](#available-clusters-and-their-state)
+6. [Deploy Application Profiles](#deploy-application-profiles)
 6. [External Access Setup (Optional)](#bring-your-own-external-access-optional)
    - [Kubernetes NGINX Ingress Controller](#kubernetes-nginx-ingress-controller)
    - [TLS Certificate](#tls-certificate)
@@ -91,21 +109,62 @@ astroctl auth login
 
 ## Deploy an EKS Cluster
 
-First, connect your AWS account, then deploy the cluster.
-
-Note: Update the YAML with your own `accountId` and `region` before deploying.
+First, link your AWS account, then deploy the cluster.
 
 ```bash
-# Connect your AWS account
-astroctl cloud aws connect --account-id <account-id> --cluster-name test-dev --region us-east-1
+# Step 1 — link your AWS account (one-time per cluster)
+# Find your account ID: aws sts get-caller-identity --query Account --output text
+astroctl cloud aws connect --account-id <YOUR_AWS_ACCOUNT_ID> --cluster-name my-cluster --region us-east-1
 
-# Deploy the cluster
+# Step 2 — deploy (update accountId and region in the YAML first)
 astroctl infra k8s apply -f cluster-template/aws/eks/byoa.yaml
 ```
 
-> **Note:** Admin access to the EKS cluster is required to deploy the services. If you need access, please contact [AstroPulse support](mailto:contact@astropulse.io). After obtaining access, run `astroctl auth login` to log in to the Astro Platform. To verify admin access, run `astroctl whoami` and check the roles section for the `admin` role.
+For GKE or AKS clusters, use the equivalent connect command:
+```bash
+# GKE: find project ID with: gcloud config get-value project
+astroctl cloud gcp connect --project-id <GCP_PROJECT_ID> --cluster-name my-cluster --region us-central1
+astroctl infra k8s apply -f cluster-template/gcp/gke/cluster.yaml
 
-For different type of clusters, check the [documentations](https://astropulse.io/docs/latest/platform/cluster-pipeline/cluster-mgmt)
+# AKS: find subscription ID with: az account show --query id --output tsv
+astroctl cloud azure connect --subscription-id <SUBSCRIPTION_ID> --resource-group <RESOURCE_GROUP> --cluster-name my-cluster --region eastus
+astroctl infra k8s apply -f cluster-template/azure/aks/byoa.yaml
+```
+
+For different cluster types, see the [documentation](https://astropulse.io/docs/latest/platform/cluster-pipeline/cluster-mgmt).
+
+## Register an Existing Cluster (BYOK)
+
+Already have a Kubernetes cluster on AWS, GCP, Azure, or on-premises? Register it without reprovisioning.
+
+```bash
+# Register using your current kubectl context
+astroctl infra k8s register --cluster-name my-cluster
+
+# Or using a specific kubeconfig/context
+astroctl infra k8s register --cluster-name my-cluster --kubeconfig ~/.kube/config --context my-context
+```
+
+A lightweight agent is deployed to your cluster that creates a secure outbound tunnel to the platform. No firewall rules required.
+
+### Link Your Cloud Provider (Optional)
+
+Cloud provider access is **optional** and only needed for platform-managed operations like version upgrades, node scaling, and deletion of cloud resources. Connect it any time after registration:
+
+```bash
+# AWS — find your account ID: aws sts get-caller-identity --query Account --output text
+astroctl cloud aws connect --account-id <AWS_ACCOUNT_ID> --cluster-name my-cluster --region <REGION>
+
+# GCP — find your project ID: gcloud config get-value project
+astroctl cloud gcp connect --project-id <GCP_PROJECT_ID> --cluster-name my-cluster --region <REGION>
+
+# Azure — find your subscription ID: az account show --query id --output tsv
+astroctl cloud azure connect --subscription-id <SUBSCRIPTION_ID> --resource-group <RESOURCE_GROUP> --cluster-name my-cluster --region <REGION>
+```
+
+Each `cloud connect` command generates a setup script and either opens it in your cloud's shell (GCP Cloud Shell) or saves it locally (AWS CloudFormation, Azure CLI script). Run it once — the platform then manages credentials automatically.
+
+See [cluster-template/byok/](cluster-template/byok/) for full details and YAML examples.
 
 ## Available Clusters and their State
 ```

--- a/app-profiles/profile1.yaml
+++ b/app-profiles/profile1.yaml
@@ -1,6 +1,9 @@
-# This profile is used to select the GCP region
-# The platform will select the cluster based on the region and provider
-profileName: profile1
-cloudProvider:
-  provider: aws # gcp 
-  region: us-west-2
+# Profile pinned to a specific cloud provider and region.
+# The platform will select the best cluster in that provider/region.
+apiVersion: platform.astropulse.io/v1
+kind: ApplicationProfile
+spec:
+  profileName: profile1
+  cloudProvider:
+    provider: aws # gcp
+    region: us-west-2

--- a/app-profiles/profile2.yaml
+++ b/app-profiles/profile2.yaml
@@ -1,4 +1,6 @@
-# This profile is used to select the cluster based on the proximity of the cluster to the user
-# This will select  cluster with in the organization.
-profileName: profile2
-
+# Auto-selected profile — selects the nearest cluster by proximity.
+# No cloud provider or cluster specified; the platform picks the lowest-latency cluster.
+apiVersion: platform.astropulse.io/v1
+kind: ApplicationProfile
+spec:
+  profileName: profile2

--- a/app-profiles/profile3.yaml
+++ b/app-profiles/profile3.yaml
@@ -4,5 +4,8 @@
 #   astroctl infra k8s get
 #
 # Usage: astroctl app profile apply -f profile3.yaml
-profileName: profile3
-clusterName: <YOUR_CLUSTER_NAME>
+apiVersion: platform.astropulse.io/v1
+kind: ApplicationProfile
+spec:
+  profileName: profile3
+  clusterName: <YOUR_CLUSTER_NAME>

--- a/app-profiles/profile3.yaml
+++ b/app-profiles/profile3.yaml
@@ -1,3 +1,8 @@
-# This profile pre-defines the cluster to be used for the application
+# Cluster-pinned profile — targets a specific cluster by name.
+#
+# Replace <YOUR_CLUSTER_NAME> with the name of a cluster visible in:
+#   astroctl infra k8s get
+#
+# Usage: astroctl app profile apply -f profile3.yaml
 profileName: profile3
-clusterName: test-dev
+clusterName: <YOUR_CLUSTER_NAME>

--- a/apps/cert-manager/cert-manager.yaml
+++ b/apps/cert-manager/cert-manager.yaml
@@ -1,15 +1,17 @@
-name: cert-manager
-profileName: profile3
-namespace: cert-manager
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://charts.jetstack.io
-      chartVersion: v1.14.5
-      chartName: cert-manager
-    values:
-     type: object
-     object:
-       installCRDs: true
-
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: cert-manager
+  profileName: profile3
+  namespace: cert-manager
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://charts.jetstack.io
+        chartVersion: v1.14.5
+        chartName: cert-manager
+      values:
+       type: object
+       object:
+         installCRDs: true

--- a/apps/clickhouse/clickhouse.yaml
+++ b/apps/clickhouse/clickhouse.yaml
@@ -1,19 +1,22 @@
-name: clickhouse
-profileName:  profile3
-namespace: clickhouse
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://charts.bitnami.com/bitnami
-      chartVersion: 6.3.0
-      chartName: clickhouse
-    # https://github.com/bitnami/charts/blob/main/bitnami/clickhouse/values.yaml
-    values:
-     type: object
-     object:
-       auth:
-         username: "clickhouse"
-         password: "clickhouse"
-       zookeeper:
-         enabled: false
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: clickhouse
+  profileName:  profile3
+  namespace: clickhouse
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://charts.bitnami.com/bitnami
+        chartVersion: 6.3.0
+        chartName: clickhouse
+      # https://github.com/bitnami/charts/blob/main/bitnami/clickhouse/values.yaml
+      values:
+       type: object
+       object:
+         auth:
+           username: "clickhouse"
+           password: "clickhouse"
+         zookeeper:
+           enabled: false

--- a/apps/confluent-kafka/confluent-operator.yaml
+++ b/apps/confluent-kafka/confluent-operator.yaml
@@ -1,16 +1,18 @@
-name: confluent-operator
-profileName: profile3
-namespace: confluent
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://packages.confluent.io/helm
-      chartVersion: 0.921.20
-      chartName: confluent-for-kubernetes
-    # follow this doc, https://docs.confluent.io/operator/current/co-deploy-cfk.html
-    values:
-     type: object
-     object:
-       namespaced: false
-
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: confluent-operator
+  profileName: profile3
+  namespace: confluent
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://packages.confluent.io/helm
+        chartVersion: 0.921.20
+        chartName: confluent-for-kubernetes
+      # follow this doc, https://docs.confluent.io/operator/current/co-deploy-cfk.html
+      values:
+       type: object
+       object:
+         namespaced: false

--- a/apps/confluent-kafka/kafka.yaml
+++ b/apps/confluent-kafka/kafka.yaml
@@ -1,12 +1,14 @@
-name: kafka-cluster
-profileName:  profile3
-namespace: kafka
-source:
-  type: yaml
-  yaml: 
-    repo: 
-      path: resources/cfk
-      repoURL: https://github.com/astropulseinc/astro-platform-apps.git
-      targetRevision: main
-    exclude: "*.md"
-
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: kafka-cluster
+  profileName:  profile3
+  namespace: kafka
+  source:
+    type: yaml
+    yaml: 
+      repo: 
+        path: resources/cfk
+        repoURL: https://github.com/astropulseinc/astro-platform-apps.git
+        targetRevision: main
+      exclude: "*.md"

--- a/apps/external-dns/aws.yaml
+++ b/apps/external-dns/aws.yaml
@@ -1,31 +1,34 @@
-name: external-dns
-profileName: profile3
-namespace: external-dns
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://charts.bitnami.com/bitnami
-      chartVersion: 8.3.9
-      chartName: external-dns
-    # https://github.com/bitnami/charts/blob/main/bitnami/external-dns/values.yaml
-    values:
-     type: object
-     object:
-       resources:
-         limits:
-           cpu: 100m
-           memory: 300Mi
-         requests:
-           cpu: 100m
-           memory: 300Mi
-       sources:
-         - service
-         - ingress
-       provider: aws
-       aws:
-         zoneType: public
-       policy: sync
-       domainFilters:
-         - astropulse.io
-       txtOwnerId: test-dev
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: external-dns
+  profileName: profile3
+  namespace: external-dns
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://charts.bitnami.com/bitnami
+        chartVersion: 8.3.9
+        chartName: external-dns
+      # https://github.com/bitnami/charts/blob/main/bitnami/external-dns/values.yaml
+      values:
+       type: object
+       object:
+         resources:
+           limits:
+             cpu: 100m
+             memory: 300Mi
+           requests:
+             cpu: 100m
+             memory: 300Mi
+         sources:
+           - service
+           - ingress
+         provider: aws
+         aws:
+           zoneType: public
+         policy: sync
+         domainFilters:
+           - astropulse.io
+         txtOwnerId: test-dev

--- a/apps/external-dns/gcp.yaml
+++ b/apps/external-dns/gcp.yaml
@@ -1,33 +1,36 @@
-name: external-dns
-profileName: profile3
-namespace: external-dns
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://charts.bitnami.com/bitnami
-      chartVersion: 7.3.2
-      chartName: external-dns
-    values:
-     type: object
-     object:
-       resources:
-         limits:
-           cpu: 100m
-           memory: 300Mi
-         requests:
-           cpu: 100m
-           memory: 300Mi
-       sources:
-         - service
-         - ingress
-       provider: google
-      # this is required if we are running outside of GCP
-      #  google:
-      #    project: <your-gcp-project-id>
-      #    serviceAccountSecret: external-dns-credentials # make sure to create this secret before deploying this app
-      # txtPrefix: a
-       policy: sync
-       domainFilters:
-         - astropulse.io
-       txtOwnerId: test-dev
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: external-dns
+  profileName: profile3
+  namespace: external-dns
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://charts.bitnami.com/bitnami
+        chartVersion: 7.3.2
+        chartName: external-dns
+      values:
+       type: object
+       object:
+         resources:
+           limits:
+             cpu: 100m
+             memory: 300Mi
+           requests:
+             cpu: 100m
+             memory: 300Mi
+         sources:
+           - service
+           - ingress
+         provider: google
+        # this is required if we are running outside of GCP
+        #  google:
+        #    project: <your-gcp-project-id>
+        #    serviceAccountSecret: external-dns-credentials # make sure to create this secret before deploying this app
+        # txtPrefix: a
+         policy: sync
+         domainFilters:
+           - astropulse.io
+         txtOwnerId: test-dev

--- a/apps/external-secret/external-secret.yaml
+++ b/apps/external-secret/external-secret.yaml
@@ -1,15 +1,18 @@
-name: external-secret-operator
-profileName: profile3
-namespace: external-secret
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://charts.external-secrets.io
-      chartVersion: v0.10.4
-      chartName: external-secrets
-    # https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
-    values:
-     type: object
-     object:
-       installCRDs: true
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: external-secret-operator
+  profileName: profile3
+  namespace: external-secret
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://charts.external-secrets.io
+        chartVersion: v0.10.4
+        chartName: external-secrets
+      # https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
+      values:
+       type: object
+       object:
+         installCRDs: true

--- a/apps/grafana/grafana.yaml
+++ b/apps/grafana/grafana.yaml
@@ -1,26 +1,29 @@
-name: grafana-service
-profileName:  profile3
-namespace: monitoring
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://grafana.github.io/helm-charts
-      chartVersion: 8.0.0
-      chartName: grafana
-    # https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
-    values:
-     type: object
-     object:
-       namespaced: false
-       persistence:
-         # make sure to use the right storage class for the PVC in the resources/ folder. Only storage classes that are created part of the cluster for eks is gp2. There will be no default storage class for the PVC. So make sure to create the storage class before deploying the application.
-         storageClassName: gp2 
-         type: pvc
-         enabled: true
-         size: 10Gi
-       adminUser: admin
-       adminPassword: 66YQ8CYImcatKjM3JDx5ykBYb9EQeQSZcKIhY6llq4
-       plugins:
-        - vertamedia-clickhouse-datasource
-        - grafana-clickhouse-datasource
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: grafana-service
+  profileName:  profile3
+  namespace: monitoring
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://grafana.github.io/helm-charts
+        chartVersion: 8.0.0
+        chartName: grafana
+      # https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+      values:
+       type: object
+       object:
+         namespaced: false
+         persistence:
+           # make sure to use the right storage class for the PVC in the resources/ folder. Only storage classes that are created part of the cluster for eks is gp2. There will be no default storage class for the PVC. So make sure to create the storage class before deploying the application.
+           storageClassName: gp2 
+           type: pvc
+           enabled: true
+           size: 10Gi
+         adminUser: admin
+         adminPassword: 66YQ8CYImcatKjM3JDx5ykBYb9EQeQSZcKIhY6llq4
+         plugins:
+          - vertamedia-clickhouse-datasource
+          - grafana-clickhouse-datasource

--- a/apps/hello-world/demo.yaml
+++ b/apps/hello-world/demo.yaml
@@ -11,16 +11,19 @@
 # Usage: astroctl app apply -f demo.yaml
 # Verify: astroctl app status hello-world
 
-name: hello-world
-# Must match an existing profile — list profiles with: astroctl app profile get
-profileName: <YOUR_PROFILE_NAME>
-source:
-  type: image
-  image:
-    registry: docker.io
-    repository: astropulse/latency
-    tag: v1.0.0
-# Uncomment to expose the app via an ingress (requires external access configured on cluster):
-# externalAccess:
-#   accessType: Ingress
-#   dnsEndpoint: "hello-world.example.com"
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: hello-world
+  # Must match an existing profile — list profiles with: astroctl app profile get
+  profileName: <YOUR_PROFILE_NAME>
+  source:
+    type: image
+    image:
+      registry: docker.io
+      repository: astropulse/latency
+      tag: v1.0.0
+  # Uncomment to expose the app via an ingress (requires external access configured on cluster):
+  # externalAccess:
+  #   accessType: Ingress
+  #   dnsEndpoint: "hello-world.example.com"

--- a/apps/hello-world/demo.yaml
+++ b/apps/hello-world/demo.yaml
@@ -1,12 +1,26 @@
+# Hello World Application
+#
+# Prerequisites:
+# 1. A cluster must exist and be READY: astroctl infra k8s get
+# 2. A profile must exist that points at your cluster.
+#    Create one: astroctl app profile apply -f profile.yaml
+#    where profile.yaml contains:
+#      profileName: <YOUR_PROFILE_NAME>
+#      clusterName: <YOUR_CLUSTER_NAME>
+#
+# Usage: astroctl app apply -f demo.yaml
+# Verify: astroctl app status hello-world
+
 name: hello-world
-profileName: profile3
+# Must match an existing profile — list profiles with: astroctl app profile get
+profileName: <YOUR_PROFILE_NAME>
 source:
- type: image
- image:
-   registry: docker.io
-   repository: astropulse/latency
-   tag: v1.0.0
-# only enable if you configure your cluster to have external access
-#  externalAccess:
-#    accessType: Ingress # this is default so not needed
-#    dnsEndpoint: "app.example.com"
+  type: image
+  image:
+    registry: docker.io
+    repository: astropulse/latency
+    tag: v1.0.0
+# Uncomment to expose the app via an ingress (requires external access configured on cluster):
+# externalAccess:
+#   accessType: Ingress
+#   dnsEndpoint: "hello-world.example.com"

--- a/apps/kube-state-metrics/ksm.yaml
+++ b/apps/kube-state-metrics/ksm.yaml
@@ -1,15 +1,18 @@
-name: prometheus
-profileName: profile3
-namespace: monitoring
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://prometheus-community.github.io/helm-charts
-      chartVersion: 5.26.0
-      chartName: kube-state-metrics
-    # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml
-    values:
-     type: object
-     object:
-       namespaced: false
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: prometheus
+  profileName: profile3
+  namespace: monitoring
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://prometheus-community.github.io/helm-charts
+        chartVersion: 5.26.0
+        chartName: kube-state-metrics
+      # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml
+      values:
+       type: object
+       object:
+         namespaced: false

--- a/apps/nginx/aws_nginx.yaml
+++ b/apps/nginx/aws_nginx.yaml
@@ -1,29 +1,32 @@
-name: nginx
-profileName: profile3
-namespace: nginx
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://kubernetes.github.io/ingress-nginx
-      chartVersion: 4.10.1
-      chartName: ingress-nginx
-    # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
-    values:
-     type: object
-     object:
-       controller:
-         extraArgs:
-           default-ssl-certificate: "cert-manager/nginx-global-default-tls-cert"
-         config:
-           limit-req-status-code: "429"
-           limit-conn-status-code: "429"
-           force-ssl-redirect: "true"
-         service:
-           annotations:
-              service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-              service.beta.kubernetes.io/aws-load-balancer-type: nlb
-              service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-              # add your arn here and if you are using arn you don't need to configure controller.extraArgs.default-ssl-certificate
-              # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: #
-              service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: nginx
+  profileName: profile3
+  namespace: nginx
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://kubernetes.github.io/ingress-nginx
+        chartVersion: 4.10.1
+        chartName: ingress-nginx
+      # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+      values:
+       type: object
+       object:
+         controller:
+           extraArgs:
+             default-ssl-certificate: "cert-manager/nginx-global-default-tls-cert"
+           config:
+             limit-req-status-code: "429"
+             limit-conn-status-code: "429"
+             force-ssl-redirect: "true"
+           service:
+             annotations:
+                service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+                service.beta.kubernetes.io/aws-load-balancer-type: nlb
+                service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+                # add your arn here and if you are using arn you don't need to configure controller.extraArgs.default-ssl-certificate
+                # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: #
+                service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance

--- a/apps/nginx/nginx-certs.yaml
+++ b/apps/nginx/nginx-certs.yaml
@@ -1,11 +1,14 @@
-name: nginx-certificates
-profileName:  profile3
-namespace: nginx
-source:
-  type: yaml
-  yaml: 
-    repo: 
-      path: resources/nginx
-      repoURL: https://github.com/astropulseinc/astro-platform-apps.git
-      targetRevision: main
-    exclude: "*.md"
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: nginx-certificates
+  profileName:  profile3
+  namespace: nginx
+  source:
+    type: yaml
+    yaml: 
+      repo: 
+        path: resources/nginx
+        repoURL: https://github.com/astropulseinc/astro-platform-apps.git
+        targetRevision: main
+      exclude: "*.md"

--- a/apps/opentelemetry/otel-collector.yaml
+++ b/apps/opentelemetry/otel-collector.yaml
@@ -1,26 +1,29 @@
-name: otel-collector-operator
-profileName: profile3
-namespace: otel-collector
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
-      chartVersion: 0.108.0
-      chartName:  opentelemetry-collector
-    # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml
-    values:
-     type: object
-     object:
-       mode: daemonset
-       image:
-          repository: otel/opentelemetry-collector-k8s
-       presets:
-         hostMetrics:
-           enabled: true
-         kubernetesEvents:
-           enabled: true
-         kubeletMetrics:
-           enabled: true
-         kubernetesAttributes:
-           enabled: true
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: otel-collector-operator
+  profileName: profile3
+  namespace: otel-collector
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
+        chartVersion: 0.108.0
+        chartName:  opentelemetry-collector
+      # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml
+      values:
+       type: object
+       object:
+         mode: daemonset
+         image:
+            repository: otel/opentelemetry-collector-k8s
+         presets:
+           hostMetrics:
+             enabled: true
+           kubernetesEvents:
+             enabled: true
+           kubeletMetrics:
+             enabled: true
+           kubernetesAttributes:
+             enabled: true

--- a/apps/prometheus/prometheus.yaml
+++ b/apps/prometheus/prometheus.yaml
@@ -1,18 +1,21 @@
-name: prometheus
-profileName: profile3
-namespace: monitoring
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: https://prometheus-community.github.io/helm-charts
-      chartVersion: 25.27.0
-      chartName: prometheus
-    # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
-    values:
-     type: object
-     object:
-       alertmanager:
-         enabled: false
-       prometheus-pushgateway:
-         enabled: false
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: prometheus
+  profileName: profile3
+  namespace: monitoring
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: https://prometheus-community.github.io/helm-charts
+        chartVersion: 25.27.0
+        chartName: prometheus
+      # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
+      values:
+       type: object
+       object:
+         alertmanager:
+           enabled: false
+         prometheus-pushgateway:
+           enabled: false

--- a/apps/strimzi/strimzi-kafka.yaml
+++ b/apps/strimzi/strimzi-kafka.yaml
@@ -1,11 +1,14 @@
-name: kafka-cluster
-profileName:  profile3
-namespace: strimzi-kafka
-source:
-  type: yaml
-  yaml: 
-    repo: 
-      path: resources/strimzi
-      repoURL: https://github.com/astropulseinc/astro-platform-apps.git
-      targetRevision: main
-    exclude: "*.md"
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: kafka-cluster
+  profileName:  profile3
+  namespace: strimzi-kafka
+  source:
+    type: yaml
+    yaml: 
+      repo: 
+        path: resources/strimzi
+        repoURL: https://github.com/astropulseinc/astro-platform-apps.git
+        targetRevision: main
+      exclude: "*.md"

--- a/apps/strimzi/strimzi.yaml
+++ b/apps/strimzi/strimzi.yaml
@@ -1,18 +1,20 @@
-name: strimzi-kafka-operator
-profileName: profile3
-namespace: strimzi-kafka
-source:
-  type: helm
-  helm: 
-    repo: 
-      repoURL: oci://quay.io/strimzi-helm
-      # the version is tied with the git tag, to find the corresponding tag, go to https://github.com/strimzi/strimzi-kafka-operator/tags
-      chartVersion: 0.43.0
-      chartName: strimzi-kafka-operator
-    # https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
-    values:
-     type: object
-     object:
-       namespaced: false
-       watchAnyNamespace: true
-
+apiVersion: platform.astropulse.io/v1
+kind: Application
+spec:
+  name: strimzi-kafka-operator
+  profileName: profile3
+  namespace: strimzi-kafka
+  source:
+    type: helm
+    helm: 
+      repo: 
+        repoURL: oci://quay.io/strimzi-helm
+        # the version is tied with the git tag, to find the corresponding tag, go to https://github.com/strimzi/strimzi-kafka-operator/tags
+        chartVersion: 0.43.0
+        chartName: strimzi-kafka-operator
+      # https://github.com/strimzi/strimzi-kafka-operator/blob/main/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+      values:
+       type: object
+       object:
+         namespaced: false
+         watchAnyNamespace: true

--- a/cluster-template/aws/eks/byo-vpc.yaml
+++ b/cluster-template/aws/eks/byo-vpc.yaml
@@ -16,28 +16,29 @@ spec:
   provisioner:
     type: eks
     eks:
-      accountId: <your account id>
+      accountId: "<YOUR_AWS_ACCOUNT_ID>"   # 12-digit AWS account ID
 
-      vpcId: <your vpc id>
-      vpcCIDR: 192.168.0.0/16
+      vpcId: "<YOUR_VPC_ID>"              # e.g. vpc-0abc1234def56789a
+      vpcCIDR: "10.0.0.0/16"             # must match your VPC CIDR block
 
-      # Subnets per AZ (public + private recommended for production)
+      # Subnets per AZ (public + private required for production)
+      # Replace all subnet-* values with your actual subnet IDs
       subnets:
         us-west-2a:
           - type: public
-            id: subnet-0b9e119bdba3f8add
+            id: "<YOUR_PUBLIC_SUBNET_2A>"   # e.g. subnet-0abc1234def56789a
           - type: private
-            id: subnet-09ad1a17f7ee64ded
+            id: "<YOUR_PRIVATE_SUBNET_2A>"
         us-west-2b:
           - type: public
-            id: subnet-019c01369039cfb22
+            id: "<YOUR_PUBLIC_SUBNET_2B>"
           - type: private
-            id: subnet-0a40e1b1bb879d47c
+            id: "<YOUR_PRIVATE_SUBNET_2B>"
         us-west-2c:
           - type: public
-            id: subnet-0be1c43d23931e8b7
+            id: "<YOUR_PUBLIC_SUBNET_2C>"
           - type: private
-            id: subnet-072d6cdf209a85b7f
+            id: "<YOUR_PRIVATE_SUBNET_2C>"
 
       credentials:
         type: dynamic

--- a/cluster-template/aws/eks/byoa.yaml
+++ b/cluster-template/aws/eks/byoa.yaml
@@ -9,7 +9,7 @@
 apiVersion: platform.astropulse.io/v1
 kind: K8sCluster
 spec:
-  clusterName: test-dev
+  clusterName: my-eks-cluster
   provider: aws
   region: us-east-1
   provisioner:

--- a/cluster-template/aws/eks/byoa.yaml
+++ b/cluster-template/aws/eks/byoa.yaml
@@ -1,7 +1,9 @@
 # EKS Cluster (Dynamic Credentials)
 #
 # Prerequisites:
-# 1. Run: astroctl cloud aws connect --account-id <account> --cluster-name <name> --region <region>
+# 1. Find your AWS account ID:
+#      aws sts get-caller-identity --query Account --output text
+# 2. Run: astroctl cloud aws connect --account-id <YOUR_AWS_ACCOUNT_ID> --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_REGION>
 #
 # Usage: astroctl infra k8s apply -f byoa.yaml
 # Docs:  https://astropulse.io/docs/latest/platform/cluster-pipeline/provisioner/managed/eks
@@ -9,13 +11,15 @@
 apiVersion: platform.astropulse.io/v1
 kind: K8sCluster
 spec:
-  clusterName: my-eks-cluster
+  clusterName: <YOUR_CLUSTER_NAME>
   provider: aws
-  region: us-east-1
+  region: <YOUR_REGION>          # e.g. us-east-1 — must match the region used in step 2 above
   provisioner:
     type: eks
     eks:
-      accountId: <your account id>
+      # 12-digit AWS account ID
+      # Find with: aws sts get-caller-identity --query Account --output text
+      accountId: "<YOUR_AWS_ACCOUNT_ID>"
 
       credentials:
         type: dynamic

--- a/cluster-template/azure/aks/byoa.yaml
+++ b/cluster-template/azure/aks/byoa.yaml
@@ -1,7 +1,12 @@
 # AKS Cluster (Dynamic Credentials)
 #
 # Prerequisites:
-# 1. Run: astroctl cloud azure connect --subscription-id <id> --resource-group <rg> --cluster-name <name> --region <region>
+# 1. Find your Azure subscription ID:
+#      az account show --query id -o tsv
+# 2. Create a resource group (if needed):
+#      az group create --name <YOUR_RESOURCE_GROUP> --location <YOUR_REGION>
+# 3. Run: astroctl cloud azure connect --subscription-id <YOUR_SUBSCRIPTION_ID> --resource-group <YOUR_RESOURCE_GROUP> --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_REGION>
+#    Then run the saved script: bash astro-azure-setup-<YOUR_CLUSTER_NAME>.sh
 #
 # Usage: astroctl infra k8s apply -f byoa.yaml
 # Docs:  https://astropulse.io/docs/latest/platform/cluster-pipeline/provisioner/managed/aks
@@ -9,14 +14,19 @@
 apiVersion: platform.astropulse.io/v1
 kind: K8sCluster
 spec:
-  clusterName: my-aks-cluster
+  clusterName: <YOUR_CLUSTER_NAME>
   provider: azure
-  region: eastus
+  region: <YOUR_REGION>          # e.g. eastus — must match the region used in step 3 above
   provisioner:
     type: aks
     aks:
-      subscriptionId: "00000000-0000-0000-0000-000000000000"
-      resourceGroup: "rg-astro-production"
+      # Azure subscription ID (UUID format)
+      # Find with: az account show --query id -o tsv
+      subscriptionId: "<YOUR_SUBSCRIPTION_ID>"
+
+      # Azure resource group where the cluster will be created
+      # Create with: az group create --name <YOUR_RESOURCE_GROUP> --location <YOUR_REGION>
+      resourceGroup: "<YOUR_RESOURCE_GROUP>"
 
       credentials:
         type: dynamic
@@ -25,12 +35,14 @@ spec:
     dataPlane:
       nodeGroups:
         # The first nodeGroup is always the system pool. The name can be anything.
+        # System pools must use ondemand — Azure does not allow spot for system pools.
         - name: systempool
           minNode: 2
           maxNode: 5
-          instanceType: ondemand  # system pools cannot use spot — AKS requires ondemand
+          instanceType: ondemand  # required for system pools — do not change to spot
           machineTypes:
-            - Standard_D2s_v7    # use az vm list-skus to check your subscription's allowed sizes
+            # Check available VM sizes for your subscription and region:
+            #   az vm list-skus --location <YOUR_REGION> --resource-type virtualMachines -o table
+            - Standard_D2s_v7
           labels:
-            environment: production
-            tier: application
+            environment: dev

--- a/cluster-template/azure/aks/byoa.yaml
+++ b/cluster-template/azure/aks/byoa.yaml
@@ -34,7 +34,8 @@ spec:
   clusterSpec:
     dataPlane:
       nodeGroups:
-        # The first nodeGroup is always the system pool. The name can be anything.
+        # The first nodeGroup is always the system pool. AKS node pool names must start with a
+        # lowercase letter, contain only lowercase alphanumeric characters, and be ≤12 chars (Linux).
         # System pools must use ondemand — Azure does not allow spot for system pools.
         - name: systempool
           minNode: 2

--- a/cluster-template/azure/aks/byoa.yaml
+++ b/cluster-template/azure/aks/byoa.yaml
@@ -24,12 +24,13 @@ spec:
   clusterSpec:
     dataPlane:
       nodeGroups:
+        # The first nodeGroup is always the system pool. The name can be anything.
         - name: systempool
           minNode: 2
           maxNode: 5
-          instanceType: ondemand  # or "spot" for cost savings
+          instanceType: ondemand  # system pools cannot use spot — AKS requires ondemand
           machineTypes:
-            - Standard_DC2as_v5
+            - Standard_D2s_v7    # use az vm list-skus to check your subscription's allowed sizes
           labels:
             environment: production
             tier: application

--- a/cluster-template/byok/register.yaml
+++ b/cluster-template/byok/register.yaml
@@ -15,13 +15,16 @@
 #
 # Documentation: https://astropulse.io/docs/latest/platform/cluster-pipeline/cluster-registration
 
-# Name for the cluster in the platform (required)
-clusterName: my-existing-cluster
+apiVersion: platform.astropulse.io/v1
+kind: K8sClusterRegistration
+spec:
+  # Name for the cluster in the platform (required)
+  clusterName: my-existing-cluster
 
-# Cloud region override (optional — auto-detected if omitted)
-# region: us-east-1
+  # Cloud region override (optional — auto-detected if omitted)
+  # region: us-east-1
 
-# Labels for organization and filtering (optional)
-# labels:
-#   environment: production
-#   team: platform
+  # Labels for organization and filtering (optional)
+  # labels:
+  #   environment: production
+  #   team: platform

--- a/cluster-template/byok/register.yaml
+++ b/cluster-template/byok/register.yaml
@@ -15,16 +15,13 @@
 #
 # Documentation: https://astropulse.io/docs/latest/platform/cluster-pipeline/cluster-registration
 
-apiVersion: platform.astropulse.io/v1
-kind: K8sClusterRegistration
-spec:
-  # Name for the cluster in the platform (required)
-  clusterName: my-existing-cluster
+# Name for the cluster in the platform (required)
+clusterName: my-existing-cluster
 
-  # Cloud region override (optional — auto-detected if omitted)
-  # region: us-east-1
+# Cloud region override (optional — auto-detected if omitted)
+# region: us-east-1
 
-  # Labels for organization and filtering (optional)
-  # labels:
-  #   environment: production
-  #   team: platform
+# Labels for organization and filtering (optional)
+# labels:
+#   environment: production
+#   team: platform

--- a/cluster-template/gcp/gke/autopilot.yaml
+++ b/cluster-template/gcp/gke/autopilot.yaml
@@ -18,7 +18,7 @@ spec:
   provisioner:
     type: gke
     gke:
-      projectId: my-gcp-project-123
+      projectId: "<YOUR_GCP_PROJECT_ID>"   # e.g. my-project-123456
 
       autopilot: true
 

--- a/cluster-template/gcp/gke/byovpc.yaml
+++ b/cluster-template/gcp/gke/byovpc.yaml
@@ -16,7 +16,7 @@ spec:
   provisioner:
     type: gke
     gke:
-      projectId: my-gcp-project-123
+      projectId: "<YOUR_GCP_PROJECT_ID>"   # e.g. my-project-123456
 
       # BYOVPC — your existing VPC network name
       networkId: my-vpc

--- a/cluster-template/gcp/gke/cluster.yaml
+++ b/cluster-template/gcp/gke/cluster.yaml
@@ -1,28 +1,36 @@
 # GKE Cluster (Dynamic Credentials)
 #
 # Prerequisites:
-# 1. Run: astroctl cloud gcp connect --project-id <project> --cluster-name <name> --region <region>
+# 1. Find your GCP project ID:
+#      gcloud config get-value project
+# 2. Enable the GKE API (once per project):
+#      gcloud services enable container.googleapis.com --project <YOUR_GCP_PROJECT_ID>
+# 3. Run: astroctl cloud gcp connect --project-id <YOUR_GCP_PROJECT_ID> --cluster-name <YOUR_CLUSTER_NAME> --region <YOUR_REGION>
 #
-# Usage: astroctl infra k8s apply -f gke.yaml
+# Usage: astroctl infra k8s apply -f cluster.yaml
 # Docs:  https://astropulse.io/docs/latest/platform/cluster-pipeline/provisioner/managed/gke
 
 apiVersion: platform.astropulse.io/v1
 kind: K8sCluster
 spec:
-  clusterName: my-gke-cluster
+  clusterName: <YOUR_CLUSTER_NAME>
   provider: gcp
-  region: us-central1
+  region: <YOUR_REGION>          # e.g. us-central1 — must match the region used in step 3 above
   provisioner:
     type: gke
     gke:
-      projectId: my-gcp-project-123
+      # GCP project ID (not project number)
+      # Find with: gcloud config get-value project
+      projectId: "<YOUR_GCP_PROJECT_ID>"   # e.g. my-project-123456
 
       credentials:
         type: dynamic
 
-      # kubernetesVersion: "1.30"         # defaults to GKE stable channel
-      # releaseChannel: STABLE             # STABLE, REGULAR, RAPID
-      # enableWorkloadIdentity: true       # default: true
+      # kubernetesVersion: "1.30.5-gke.1443001"  # GKE version format; omit to use channel default
+      # releaseChannel: STABLE                    # STABLE (default), REGULAR, RAPID
+      # enableWorkloadIdentity: true              # default: true — enables pod-level GCP IAM
+      # Fleet enrollment is automatic — the platform registers the cluster in GCP Fleet Hub
+      # during creation to enable Connect Gateway. No manual steps required.
 
   clusterSpec:
     dataPlane:
@@ -34,5 +42,4 @@ spec:
           machineTypes:
             - e2-standard-2
           labels:
-            environment: production
-            tier: application
+            environment: dev


### PR DESCRIPTION
## Summary

All cluster templates and app examples are now copy-paste ready — every placeholder is `<SCREAMING_SNAKE_CASE>` with an inline comment showing the exact command to find the value.

### Cluster templates

| Template | Changes |
|----------|---------|
| `cluster-template/aws/eks/byoa.yaml` | `aws sts get-caller-identity` lookup comment; `<YOUR_CLUSTER_NAME>` / `<YOUR_REGION>` placeholders |
| `cluster-template/azure/aks/byoa.yaml` | `az account show` + `az group create` comments; system pool `ondemand`, `minNode: 2`, `Standard_D2s_v7`; 3-step connect prerequisite block |
| `cluster-template/gcp/gke/cluster.yaml` | `gcloud config get-value project` + `gcloud services enable` comments; Fleet Hub auto-enrollment note |
| `cluster-template/byok/register.yaml` | Correct `astroctl infra k8s register` format |

### App examples

- `apps/hello-world/demo.yaml` — `<YOUR_CLUSTER_NAME>` + `<YOUR_PROFILE_NAME>` placeholders with prerequisite comments
- `app-profiles/profile3.yaml` — consistent `<YOUR_CLUSTER_NAME>` placeholder

## Test plan

- [ ] Copy `cluster-template/aws/eks/byoa.yaml`, fill in the placeholders following the comments — `astroctl infra k8s apply -f` succeeds
- [ ] Copy `cluster-template/azure/aks/byoa.yaml`, same
- [ ] Copy `cluster-template/gcp/gke/cluster.yaml`, same
- [ ] Copy `apps/hello-world/demo.yaml` after cluster is ready — app deploys